### PR TITLE
Support symfony/expression-language 4 and 5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,6 @@
     },
     "require": {
         "phpunit/phpunit": "^7.0|^8.0|^9.0",
-        "symfony/expression-language": "^3.3"
+        "symfony/expression-language": "^3.3|^4.0|5.0"
     }
 }


### PR DESCRIPTION
I don't see any signifficant changes in the changelog